### PR TITLE
Fixed installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ GPUifyLoops is an unregistered package, and can be installed using the Julia pac
 manager.
 
 ```julia
-Pkg.dev("https:\\github.com/vchuravy/GPUifyLoops.jl")
+julia>]
+(v1.1) pkg> develop https://github.com/vchuravy/GPUifyLoops.jl
 ```
 
 **Note**: The current verion of this package requires Julia 1.0, but the preferred version is Julia 1.1


### PR DESCRIPTION
Just trying to play around with this package for stencil computations. Noticed the instructions didn't work in 1.1 as `Pkg.dev()` doesn't exist anymore.