### PR TITLE
Remove Requires from test target

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,4 +12,4 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Requires", "Pkg"]
+test = ["Test", "Pkg"]


### PR DESCRIPTION
Requires is not need in the test target since it is now a project
dependency.

This allows the following code to work

```
julia --project=. -e "using Pkg; Pkg.test()"
```