### PR TITLE
loop unroll expects MDNodes

### DIFF
--- a/src/loopinfo.jl
+++ b/src/loopinfo.jl
@@ -14,9 +14,9 @@ export @unroll
 
 module MD
     unroll_count(n) = (Symbol("llvm.loop.unroll.count"), convert(Int, n))
-    unroll_disable() = Symbol("llvm.loop.unroll.disable")
-    unroll_enable() = Symbol("llvm.loop.unroll.enable")
-    unroll_full() = Symbol("llvm.loop.unroll.full")
+    unroll_disable() = (Symbol("llvm.loop.unroll.disable"), 1)
+    unroll_enable() = (Symbol("llvm.loop.unroll.enable"), 1)
+    unroll_full() = (Symbol("llvm.loop.unroll.full"), 1)
 end
 
 function loopinfo(expr, nodes...)


### PR DESCRIPTION
cc: @lcw

this get's us to:
```
remark: /home/vchuravy/src/GPUifyLoops/debug.jl:5:0: Unable to fully unroll loop as directed by unroll(full) pragma because loop has a runtime trip count.
  partially unrolling with count: 8
  Can't unroll; loop not terminated by a conditional branch.
i = 1Loop Unroll: F[julia_print_12411] Loop %L3
  Loop Size = 6
```

for:
```julia
using GPUifyLoops

@noinline iteration(i) = @show i

f(i) = @unroll for i in 1:10
          for j in i
            if j == 2
              continue
            end
            iteration((i-1)*2 + j)
          end
       end
```