### PR TITLE
Remove CUDAnative in global scope dependency

### DIFF
--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -10,8 +10,8 @@ macro shmem(T, Dims)
             $MArray{Tuple{$(dims...)}, $T}(undef)
         else
             len = prod($Dims)
-            ptr = CUDAnative._shmem(Val($id), $T, Val(len))
-            CUDAnative.CuDeviceArray($Dims, CUDAnative.DevicePtr{$T, CUDAnative.AS.Shared}(ptr))
+            ptr = $CUDAnative._shmem(Val($id), $T, Val(len))
+            $CUDAnative.CuDeviceArray($Dims, $CUDAnative.DevicePtr{$T, $CUDAnative.AS.Shared}(ptr))
         end
     end)
 end


### PR DESCRIPTION
This allows the `@shmem` macro to work even if CUDAnative is not in
global scope.

Co-authored-by: Lucas C Wilcox <lucas@swirlee.com>
Co-authored-by: Jeremy E Kozdon <jekozdon@nps.edu>