### PR TITLE
Remove CUDAnative in global scope dependency

### DIFF
--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -3,16 +3,18 @@ shmem_id = 0
 @init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
     using .CUDAnative
 
-    @inline function _shmemcu(::Type{T}, ::Val{N}, ::Val{J}) where {T, N, J}
-      len = prod(N)
-      ptr = CUDAnative._shmem(J, T, len)
-      CUDAnative.CuDeviceArray(N, CUDAnative.DevicePtr{T, CUDAnative.AS.Shared}(ptr))
+    @inline function _shmemcu(::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id}
+      ptr = CUDAnative._shmem(Val(id), T, Val(N))
+      CuDeviceArray(N, DevicePtr{T, CUDAnative.AS.Shared}(ptr))
     end
+    _shmemcuarray(A::CUDAnative.CuDeviceArray, shape) = CUDAnative.CuDeviceArray(shape, pointer(A))
 end
 
-_shmem(::Type{T}, ::Val{N}, ::Val{J}) where {T, N, J} = nothing
+_shmem(::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id} = nothing
+_shmemarray(A, shape) = nothing
 
 Cassette.overdub(ctx::Ctx, ::typeof(_shmem), args...) = _shmemcu(args...)
+Cassette.overdub(ctx::Ctx, ::typeof(_shmemarray), args...) = _shmemcuarray(args...)
 
 macro shmem(T, Dims)
     global shmem_id
@@ -23,7 +25,8 @@ macro shmem(T, Dims)
         if !$isdevice()
             $MArray{Tuple{$(dims...)}, $T}(undef)
         else
-            _shmem(Val($T), Val(Dims), Val($id))
+          ptr = $_shmem($T, Val($Dims), Val($id))
+          $_shmemarray(ptr, $Dims)
         end
     end)
 end

--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -1,5 +1,19 @@
 shmem_id = 0
 
+@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+    using .CUDAnative
+
+    @inline function _shmemcu(::Type{T}, ::Val{N}, ::Val{J}) where {T, N, J}
+      len = prod(N)
+      ptr = CUDAnative._shmem(J, T, len)
+      CUDAnative.CuDeviceArray(N, CUDAnative.DevicePtr{T, CUDAnative.AS.Shared}(ptr))
+    end
+end
+
+_shmem(::Type{T}, ::Val{N}, ::Val{J}) where {T, N, J} = nothing
+
+Cassette.overdub(ctx::Ctx, ::typeof(_shmem), args...) = _shmemcu(args...)
+
 macro shmem(T, Dims)
     global shmem_id
     id = shmem_id::Int += 1
@@ -9,9 +23,7 @@ macro shmem(T, Dims)
         if !$isdevice()
             $MArray{Tuple{$(dims...)}, $T}(undef)
         else
-            len = prod($Dims)
-            ptr = $CUDAnative._shmem(Val($id), $T, Val(len))
-            $CUDAnative.CuDeviceArray($Dims, $CUDAnative.DevicePtr{$T, $CUDAnative.AS.Shared}(ptr))
+            _shmem(Val($T), Val(Dims), Val($id))
         end
     end)
 end

--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -10,8 +10,8 @@ macro shmem(T, Dims)
             $MArray{Tuple{$(dims...)}, $T}(undef)
         else
             len = prod($Dims)
-            ptr = CUDAnative._shmem(Val($id), $T, Val(len))
-            CUDAnative.CuDeviceArray($Dims, CUDAnative.DevicePtr{$T, CUDAnative.AS.Shared}(ptr))
+            ptr = $CUDAnative._shmem(Val($id), $T, Val(len))
+            $CUDAnative.CuDeviceArray($Dims, $CUDAnative.DevicePtr{$T, $CUDAnative.AS.Shared}(ptr))
         end
     end)
 end

--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -1,20 +1,5 @@
-
-_shmem(::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id} = nothing
-_shmemarray(A, shape) = nothing
-
-@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
-    using .CUDAnative
-
-    @inline function Cassette.overdub(ctx::Ctx, ::typeof(_shmem), ::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id}
-        ptr = CUDAnative._shmem(Val(id), T, Val(N))
-        CuDeviceArray(N, DevicePtr{T, CUDAnative.AS.Shared}(ptr))
-    end
-    @inline function Cassette.overdub(ctx::Ctx, ::typeof(_shmemarray), A::CUDAnative.CuDeviceArray, shape)
-        CUDAnative.CuDeviceArray(shape, pointer(A))
-    end
-end
-
 shmem_id = 0
+
 macro shmem(T, Dims)
     global shmem_id
     id = shmem_id::Int += 1
@@ -24,8 +9,10 @@ macro shmem(T, Dims)
         if !$isdevice()
             $MArray{Tuple{$(dims...)}, $T}(undef)
         else
-          ptr = $_shmem($T, Val($Dims), Val($id))
-          $_shmemarray(ptr, $Dims)
+            len = prod($Dims)
+            ptr = $GPUifyLoops.CUDAnative._shmem(Val($id), $T, Val(len))
+            ptr = $GPUifyLoops.CUDAnative.DevicePtr{$T, $GPUifyLoops.CUDAnative.AS.Shared}(ptr)
+            $GPUifyLoops.CUDAnative.CuDeviceArray($Dims, ptr)
         end
     end)
 end

--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -1,21 +1,20 @@
-shmem_id = 0
-
-@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
-    using .CUDAnative
-
-    @inline function _shmemcu(::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id}
-      ptr = CUDAnative._shmem(Val(id), T, Val(N))
-      CuDeviceArray(N, DevicePtr{T, CUDAnative.AS.Shared}(ptr))
-    end
-    _shmemcuarray(A::CUDAnative.CuDeviceArray, shape) = CUDAnative.CuDeviceArray(shape, pointer(A))
-end
 
 _shmem(::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id} = nothing
 _shmemarray(A, shape) = nothing
 
-Cassette.overdub(ctx::Ctx, ::typeof(_shmem), args...) = _shmemcu(args...)
-Cassette.overdub(ctx::Ctx, ::typeof(_shmemarray), args...) = _shmemcuarray(args...)
+@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+    using .CUDAnative
 
+    @inline function Cassette.overdub(ctx::Ctx, ::typeof(_shmem), ::Type{T}, ::Val{N}, ::Val{id}) where {T, N, id}
+        ptr = CUDAnative._shmem(Val(id), T, Val(N))
+        CuDeviceArray(N, DevicePtr{T, CUDAnative.AS.Shared}(ptr))
+    end
+    @inline function Cassette.overdub(ctx::Ctx, ::typeof(_shmemarray), A::CUDAnative.CuDeviceArray, shape)
+        CUDAnative.CuDeviceArray(shape, pointer(A))
+    end
+end
+
+shmem_id = 0
 macro shmem(T, Dims)
     global shmem_id
     id = shmem_id::Int += 1


### PR DESCRIPTION
This allows the `@shmem` macro to work even if CUDAnative is not in
global scope.

Co-authored-by: Lucas C Wilcox <lucas@swirlee.com>
Co-authored-by: Jeremy E Kozdon <jekozdon@nps.edu>