### PR TITLE
Remove CUDAnative in global scope dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUifyLoops"
 uuid = "ba82f77b-6841-5d2e-bd9f-4daf811aec27"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"

--- a/examples/shmem.jl
+++ b/examples/shmem.jl
@@ -1,0 +1,31 @@
+using GPUifyLoops
+
+function kernel3!(A)
+    s1 = @shmem eltype(A) (1024,)
+    s2 = @shmem eltype(A) (1024,)
+
+    @loop for i in (1:size(A,1); threadIdx().x)
+        s1[i] = 2*A[i]
+        s2[i] = 3*A[i]
+    end
+    @synchronize
+    @loop for i in (1:size(A,1); threadIdx().x)
+        A[i] = s1[i]
+    end
+    nothing
+end
+
+data = rand(Float32, 1024)
+cpudata = copy(data)
+
+@launch CPU() kernel3!(cpudata)
+@assert cpudata ≈ 2 .* data
+
+@static if Base.find_package("CuArrays") !== nothing
+  using CuArrays
+  using CUDAnative
+
+  cudata = CuArray(data)
+  @launch CUDA() threads=length(cudata) kernel3!(cudata)
+  @assert Array(cudata) ≈ 2 .* data
+end

--- a/src/shmem.jl
+++ b/src/shmem.jl
@@ -1,17 +1,22 @@
-shmem_id = 0
+__shmem(D::Device, args...) = throw(MethodError(__shmem, (D, args...)))
+@inline __shmem(::CPU, ::Type{T}, ::Val{dims}, ::Val) where {T, dims} = MArray{Tuple{dims...}, T}(undef)
 
-macro shmem(T, Dims)
+
+@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+    using .CUDAnative
+
+    @inline function __shmem(::CUDA, ::Type{T}, ::Val{dims}, ::Val{id}) where {T, dims, id}
+        ptr = CUDAnative._shmem(Val(id), T, Val(prod(dims)))
+        CUDAnative.CuDeviceArray(dims, CUDAnative.DevicePtr{T, CUDAnative.AS.Shared}(ptr))
+    end
+end
+
+shmem_id = 0
+macro shmem(T, dims)
     global shmem_id
     id = shmem_id::Int += 1
 
-    dims = Dims.args
-    esc(quote
-        if !$isdevice()
-            $MArray{Tuple{$(dims...)}, $T}(undef)
-        else
-            len = prod($Dims)
-            ptr = CUDAnative._shmem(Val($id), $T, Val(len))
-            CUDAnative.CuDeviceArray($Dims, CUDAnative.DevicePtr{$T, CUDAnative.AS.Shared}(ptr))
-        end
-    end)
+    quote
+        $__shmem($backend(), $(esc(T)), Val($(esc(dims))), Val($id))
+    end
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -99,6 +99,7 @@ end
 
     @static if Base.find_package("CuArrays") !== nothing
         using CuArrays
+        using CUDAnative
 
         cudata = CuArray(data)
         @launch CUDA() threads=length(cudata) kernel3!(cudata)


### PR DESCRIPTION
This allows the `@shmem` macro to work even if CUDAnative is not in
global scope.

replaces #44 