### PR TITLE
add reflection function to overdub list, due to at_pure constraints

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -62,10 +62,15 @@ const ctx = Cassette.disablehooks(Ctx(pass = GPUifyPass))
 # Cassette fixes
 ###
 Cassette.overdub(::Ctx, ::typeof(Core.kwfunc), f) = return Core.kwfunc(f)
+@inline Cassette.overdub(::Ctx, ::typeof(Base.isimmutable), x) = return Base.isimmutable(x)
+@inline Cassette.overdub(::Ctx, ::typeof(Base.isstructtype), t) = return Base.isstructtype(t)
+@inline Cassette.overdub(::Ctx, ::typeof(Base.isprimitivetype), t) = return Base.isprimitivetype(t)
+@inline Cassette.overdub(::Ctx, ::typeof(Base.isbitstype), t) = return Base.isbitstype(t)
+@inline Cassette.overdub(::Ctx, ::typeof(Base.isbits), x) = return Base.isbits(x)
 
 @init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
     using .CUDAnative
-    Cassette.overdub(::Ctx, ::typeof(CUDAnative.datatype_align), ::Type{T}) where {T} = CUDAnative.datatype_align(T)
+    @inline Cassette.overdub(::Ctx, ::typeof(CUDAnative.datatype_align), ::Type{T}) where {T} = CUDAnative.datatype_align(T)
 end
 
 ###


### PR DESCRIPTION
Due to https://github.com/jrevels/Cassette.jl/issues/108 we need to manually escape functions that Base marks `@pure`.

This fixes #52 since `StaticArrays` calls `isbitstype`.