### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ In order to test this package locally you need to do:
 ```
 julia --project=test/gpuenv
 julia> ]
-(v1.1) pkg> resolve
-(v1.1) pkg> instantiate
+(gpuenv) pkg> resolve
+(gpuenv) pkg> instantiate
 ```
 
 This will resolve the GPU environment, please do not checking changes to `test/gpuenv/`.


### PR DESCRIPTION
If you start julia with `julia --project=test/gpuenv`, then when you enter the Pkg REPL mode, the prompt will be `(gpuenv) pkg>` (not `(v1.1) pkg>` as the README currently says.).

This pull request corrects the README.