### PR TITLE
Laplacian stencil example

### DIFF
--- a/examples/laplacian_stencil.jl
+++ b/examples/laplacian_stencil.jl
@@ -44,3 +44,11 @@ B = floor(Int, N / T)
 
 @benchmark CuArrays.@sync @launch CUDA() threads=(T, T, T) blocks=(B, B, B) laplacian!(u, v, w, ∇)
 
+function laplacian_stencil!(u, v, w, ∇)
+    for (i, j, k, uₛ, vₛ, wₛ) in stencil((Nx, Ny, Nz), u, v, w)
+        @inbounds ∇[i, j, k] = ∇²(2, 2, 2, u, v, w)
+    end
+end
+
+@benchmark CuArrays.@sync @launch CUDA() threads=(T, T, T) blocks=(B, B, B) laplacian_stencil!(u, v, w, ∇)
+

--- a/examples/laplacian_stencil.jl
+++ b/examples/laplacian_stencil.jl
@@ -1,4 +1,8 @@
-using CuArrays, OffsetArrays, GPUifyLoops
+using Adapt, CUDAnative, CuArrays, OffsetArrays, GPUifyLoops
+using BenchmarkTools
+
+# Adapt an offset CuArray to work nicely with CUDA kernels.
+Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(adapt(to, parent(x)), x.offsets)
 
 const N = 512
 const Nx, Ny, Nz = N, N, N
@@ -7,7 +11,7 @@ const Δx, Δy, Δz = 1, 1, 1
 # Difference operators on a staggered grid.
 @inline δx(i, j, k, f) = @inbounds f[i,   j, k] - f[i-1, j, k]
 @inline δy(i, j, k, f) = @inbounds f[i, j,   k] - f[i, j-1, k]
-@inline δz(f, i, j, k) = @inbounds f[i, j, k-1] - f[i, j,   k]
+@inline δz(i, j, k, f) = @inbounds f[i, j,   k] - f[i, j, k-1]
 
 @inline δx²(i, j, k, f) = δx(i+1, j,     k, f) - δx(i, j, k, f)
 @inline δy²(i, j, k, f) = δy(i,   j+1,   k, f) - δy(i, j, k, f)
@@ -15,27 +19,28 @@ const Δx, Δy, Δz = 1, 1, 1
 
 @inline ∇²(i, j, k, u, v, w) = δx²(i, j, k, u) / Δx^2 + δy²(i, j, k, v) / Δy^2 + δz²(i, j, k, w) / Δz^2
 
-function laplacian!(u, v, w, ∇²)
+function laplacian!(u, v, w, ∇)
     @loop for k in (1:Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
         @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
             @loop for i in (1:Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
-                @inbounds ∇²[i, j, k] = ∇²(i, j, k, u, v, w)
+                @inbounds ∇[i, j, k] = ∇²(i, j, k, u, v, w)
             end
         end
     end
 end
 
-u  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
-v  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
-w  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
-∇² = zeros(Nx+2, Ny+2, Nz+2) |> CuArray
+u  = rand(Nx+2, Ny+2, Nz+2) |> CuArray
+v  = rand(Nx+2, Ny+2, Nz+2) |> CuArray
+w  = rand(Nx+2, Ny+2, Nz+2) |> CuArray
+∇ = zeros(Nx+2, Ny+2, Nz+2) |> CuArray
 
-u  = OffsetArray(u,  0:Nx+1, 0:Ny+1, 0:Nz+1)
-v  = OffsetArray(v,  0:Nx+1, 0:Ny+1, 0:Nz+1)
-w  = OffsetArray(w,  0:Nx+1, 0:Ny+1, 0:Nz+1)
-∇² = OffsetArray(∇², 0:Nx+1, 0:Ny+1, 0:Nz+1)
+u = OffsetArray(u, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+v = OffsetArray(v, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+w = OffsetArray(w, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+∇ = OffsetArray(∇, 0:Nx+1, 0:Ny+1, 0:Nz+1)
 
 T = floor(Int, ∛N)
 B = floor(Int, N / T)
-@launch CUDA() threads=(T, T, T) blocks=(B, B, B) laplacian!(u, v, w, ∇²)
+
+@benchmark CuArrays.@sync @launch CUDA() threads=(T, T, T) blocks=(B, B, B) laplacian!(u, v, w, ∇)
 

--- a/examples/laplacian_stencil.jl
+++ b/examples/laplacian_stencil.jl
@@ -1,6 +1,8 @@
 using Adapt, CUDAnative, CuArrays, OffsetArrays, GPUifyLoops
 using BenchmarkTools
 
+using GPUifyLoops: stencil
+
 # Adapt an offset CuArray to work nicely with CUDA kernels.
 Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(adapt(to, parent(x)), x.offsets)
 
@@ -46,7 +48,7 @@ B = floor(Int, N / T)
 
 function laplacian_stencil!(u, v, w, ∇)
     for (i, j, k, uₛ, vₛ, wₛ) in stencil((Nx, Ny, Nz), u, v, w)
-        @inbounds ∇[i, j, k] = ∇²(2, 2, 2, u, v, w)
+        @inbounds ∇[i, j, k] = ∇²(2, 2, 2, uₛ, vₛ, wₛ)
     end
 end
 

--- a/examples/laplacian_stencil.jl
+++ b/examples/laplacian_stencil.jl
@@ -1,0 +1,41 @@
+using CuArrays, OffsetArrays, GPUifyLoops
+
+const N = 512
+const Nx, Ny, Nz = N, N, N
+const Δx, Δy, Δz = 1, 1, 1
+
+# Difference operators on a staggered grid.
+@inline δx(i, j, k, f) = @inbounds f[i,   j, k] - f[i-1, j, k]
+@inline δy(i, j, k, f) = @inbounds f[i, j,   k] - f[i, j-1, k]
+@inline δz(f, i, j, k) = @inbounds f[i, j, k-1] - f[i, j,   k]
+
+@inline δx²(i, j, k, f) = δx(i+1, j,     k, f) - δx(i, j, k, f)
+@inline δy²(i, j, k, f) = δy(i,   j+1,   k, f) - δy(i, j, k, f)
+@inline δz²(i, j, k, f) = δz(i,   j,   k+1, f) - δz(i, j, k, f)
+
+@inline ∇²(i, j, k, u, v, w) = δx²(i, j, k, u) / Δx^2 + δy²(i, j, k, v) / Δy^2 + δz²(i, j, k, w) / Δz^2
+
+function laplacian!(u, v, w, ∇²)
+    @loop for k in (1:Nz; (blockIdx().z - 1) * blockDim().z + threadIdx().z)
+        @loop for j in (1:Ny; (blockIdx().y - 1) * blockDim().y + threadIdx().y)
+            @loop for i in (1:Nx; (blockIdx().x - 1) * blockDim().x + threadIdx().x)
+                @inbounds ∇²[i, j, k] = ∇²(i, j, k, u, v, w)
+            end
+        end
+    end
+end
+
+u  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
+v  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
+w  =  rand(Nx+2, Ny+2, Nz+2) |> CuArray
+∇² = zeros(Nx+2, Ny+2, Nz+2) |> CuArray
+
+u  = OffsetArray(u,  0:Nx+1, 0:Ny+1, 0:Nz+1)
+v  = OffsetArray(v,  0:Nx+1, 0:Ny+1, 0:Nz+1)
+w  = OffsetArray(w,  0:Nx+1, 0:Ny+1, 0:Nz+1)
+∇² = OffsetArray(∇², 0:Nx+1, 0:Ny+1, 0:Nz+1)
+
+T = floor(Int, ∛N)
+B = floor(Int, N / T)
+@launch CUDA() threads=(T, T, T) blocks=(B, B, B) laplacian!(u, v, w, ∇²)
+

--- a/examples/sum_stencil.jl
+++ b/examples/sum_stencil.jl
@@ -1,0 +1,35 @@
+using Adapt, CUDAnative, CuArrays, OffsetArrays, GPUifyLoops
+using Test, BenchmarkTools
+
+using GPUifyLoops: stencil, Full
+
+# Adapt an offset CuArray to work nicely with CUDA kernels.
+Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(adapt(to, parent(x)), x.offsets)
+
+const N = 32
+const Nx, Ny, Nz = N, N, N
+const Δx, Δy, Δz = 1, 1, 1
+
+u = ones(Nx+2, Ny+2, Nz+2) |> CuArray
+v = 2 .* ones(Nx+2, Ny+2, Nz+2) |> CuArray
+w = 4 .* ones(Nx+2, Ny+2, Nz+2) |> CuArray
+S = zeros(Nx+2, Ny+2, Nz+2) |> CuArray
+
+u = OffsetArray(u, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+v = OffsetArray(v, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+w = OffsetArray(w, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+S = OffsetArray(S, 0:Nx+1, 0:Ny+1, 0:Nz+1)
+
+T = min(16, floor(Int, √N))
+B = ceil(Int, N / T)
+
+function sum_stencil!(u, v, w, S)
+    for (i, j, k, uₛ, vₛ, wₛ) in stencil((Nx, Ny, Nz), Full(), u, v, w)
+        @inbounds S[i, j, k] = uₛ[2, 2, 2] + vₛ[2, 2, 2] + wₛ[2, 2, 2]
+    end
+end
+
+@launch CUDA() threads=(T, T, 1) blocks=(B, B, 1) shmem=((T+2)*(T+2)*sizeof(Float64)) sum_stencil!(u, v, w, S)
+
+@test all(S[1:Nx, 1:Ny, 1:Nz] .≈ 7)
+

--- a/src/GPUifyLoops.jl
+++ b/src/GPUifyLoops.jl
@@ -234,4 +234,7 @@ include("shmem.jl")
 include("loopinfo.jl")
 using .LoopInfo
 
+export stencil
+include("stencil.jl")
+
 end

--- a/src/custencil.jl
+++ b/src/custencil.jl
@@ -1,8 +1,8 @@
 module CuStencil
 
-import .GPUifyLoops: SevenPoint, Full
+import ..GPUifyLoops: SevenPoint, Full
 
-using .CUDAnative
+using ..CUDAnative
 using StaticArrays
 
 # TODO:
@@ -14,7 +14,7 @@ struct Stencil{N, Dim, Kind, Shmem, U}
     buf::Shmem
     arrays::U
     Stencil{N}(dims::Dim, kind::Kind, shmem::Shmem, arrays::U) where {N, Dim, Kind, Shmem, U} =
-        new{N, Kind, Shmem, U}(dims, shmem, arrays) 
+        new{N, Dim, Kind, Shmem, U}(dims, shmem, arrays) 
 end
 
 # note this 3D only
@@ -85,7 +85,7 @@ function Base.iterate(stencil::Stencil{N, Kind}) where {N, Kind}
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     k = 1
     I, J, K = stencil.dims
-    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+    if !(i in 1:I && j in 1:J && k in 1:K)
         return nothing
     end
 
@@ -115,7 +115,7 @@ function Base.iterate(stencil::Stencil{N, Kind}, (regions, k)) where {N, Kind}
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
 
     I, J, K = stencil.dims
-    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+    if !(i in 1:I && j in 1:J && k in 1:K)
         return nothing
     end
 

--- a/src/custencil.jl
+++ b/src/custencil.jl
@@ -40,29 +40,31 @@ function load_stencil!(::Type{Kind}, buf, data, i, j, k) where Kind
 
     full = Kind <: Full
 
+    # @cuprintf("Greetings from block %ld, thread %ld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
+
     @inbounds begin
         buf[m, n] =  data[i, j, k]
 
         if m == 2
             buf[m-1, n] = data[i-1, j, k]
             if full && n == 2
-                buf[m-1, n-1, k] = data[i, j-1, k]
+                buf[m-1, n-1] = data[i, j-1, k]
             elseif full && n == N 
-                buf[m-1, n+1, k] = data[i, j+1, k]
+                buf[m-1, n+1] = data[i, j+1, k]
             end
         elseif m == M
             buf[m+1, n] = data[i+1, j, k]
             if full && n == 2
-                buf[m+1, n-1, k] = data[i, j-1, k]
+                buf[m+1, n-1] = data[i, j-1, k]
             elseif full && n == N 
-                buf[m+1, n+1, k] = data[i, j+1, k]
+                buf[m+1, n+1] = data[i, j+1, k]
             end
         end
 
         if n == 2
-            buf[m, n-1, k] = data[i, j-1, k]
+            buf[m, n-1] = data[i, j-1, k]
         elseif n == N 
-            buf[m, n+1, k] = data[i, j+1, k]
+            buf[m, n+1] = data[i, j+1, k]
         end
     end
 

--- a/src/custencil.jl
+++ b/src/custencil.jl
@@ -1,0 +1,112 @@
+module CuStencil
+
+using .CUDAnative
+using StaticArrays
+
+    # TODO: Add an option to load in the full 3x3x3x stencil including
+    # the 1,1 and I+1,I+1 corners
+
+struct Stencil{N, Dim, Shmem, U}
+    dims::Dim
+    buf::Shmem
+    arrays::U
+    Stencil{N}(dims, shmem, arrays) where N = new{N, typeof(dims), typeof(shmem), typeof(arrays)}(dims, shmem, arrays) 
+end
+
+# note this 3D only
+function stencil(dims, args::Vararg{<:Any, N}) where N
+    eltypes = map(eltype, args)
+    T = reduce(promote_type, eltypes)
+    @assert Base.isconcretetype(T)
+
+    buf = @cuDynamicSharedMem T (blockDim().x+2, blockDim().y+2)
+    Stencil{N}(dims, buf, args)
+end
+
+function load_stencil!(buf, data, i, j, k)
+    # translate between local to global indices
+    m = threadIdx().x
+    n = threadIdx().y
+    # halo region 
+    m, n = m+1, n+1
+
+    buf[m, n] =  data[i, j, k]
+
+    if m == 2 
+        buf[m-1, n] = data[i-1, j, k]
+    else m == blockDim().x+1 # boundary of block
+        buf[m+1, n] = data[i+1, j, k]
+    end
+    if n == 2
+        buf[m, n-1, k] = data[i, j-1, k]
+    else n == blockDim().y+1 # boundary of block
+        buf[m, n+1, k] = data[i, j+1, k]
+    end
+    # NOTE we don't load in the corners yet
+    sync_warp()
+    return m, n
+end
+
+function load_slice(buf,m,n)
+    # SMatrix{3,3}(view(buf, m-1:m+1, n-1:n+1))
+    inds = CartesianIndices((m-1:m+1, n-1:n+1))
+    data = ntuple(Val(9)) do i
+        buf[inds[i]]
+    end
+    SMatrix{3,3}(data)
+end
+
+function Base.iterate(stencil::Stencil{N}) where N
+    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    k = 1
+    I, J, K = stencil.dims
+    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+        return nothing
+    end
+
+    buf = stencil.buf
+
+    regions = ntuple(Val(N)) do ind
+        data = stencil.arrays[ind]
+        # load the boundary
+        m, n = load_stencil!(buf, data, i, j, k-1)
+        pre = load_slice(buf, m, n)
+
+        m, n = load_stencil!(buf, data, i, j, k)
+        current = load_slice(buf, m, n)
+
+        m, n = load_stencil!(buf, data, i, j, k+1)
+        next = load_slice(buf, m, n)
+
+        ldata = cat(pre, current, next, dims=3)
+    end
+
+    ((i,j,k,regions...), (regions, k+1))
+end
+
+
+function Base.iterate(stencil::Stencil{N}, (regions, k)) where N
+    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+
+    I, J, K = stencil.dims
+    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+        return nothing
+    end
+
+    buf = stencil.buf
+
+    next_regions = ntuple(Val(N)) do ind
+        data = stencil.arrays[ind]
+        old = regions[ind]
+
+        m, n = load_stencil!(buf, data, i, j, k+1)
+        next = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
+        ldata = cat(old[:,:,2], old[:,:,3], next, dims=3)
+    end
+
+    ((i,j,k, next_regions...), (next_regions, k+1))
+end
+
+end

--- a/src/custencil.jl
+++ b/src/custencil.jl
@@ -20,7 +20,8 @@ end
 # note this 3D only
 function stencil(dims, kind, args::Vararg{<:Any, N}) where N
     eltypes = map(eltype, args)
-    T = reduce(promote_type, eltypes)
+    T = eltypes[1]
+    #T = reduce(promote_type, eltypes)
     @assert Base.isconcretetype(T)
 
     buf = @cuDynamicSharedMem T (blockDim().x+2, blockDim().y+2)
@@ -40,24 +41,22 @@ function load_stencil!(::Type{Kind}, buf, data, i, j, k) where Kind
 
     full = Kind <: Full
 
-    # @cuprintf("Greetings from block %ld, thread %ld!\n", Int64(blockIdx().x), Int64(threadIdx().x))
-
     @inbounds begin
         buf[m, n] =  data[i, j, k]
 
         if m == 2
             buf[m-1, n] = data[i-1, j, k]
             if full && n == 2
-                buf[m-1, n-1] = data[i, j-1, k]
+                buf[m-1, n-1] = data[i-1, j-1, k]
             elseif full && n == N 
-                buf[m-1, n+1] = data[i, j+1, k]
+                buf[m-1, n+1] = data[i-1, j+1, k]
             end
         elseif m == M
             buf[m+1, n] = data[i+1, j, k]
             if full && n == 2
-                buf[m+1, n-1] = data[i, j-1, k]
+                buf[m+1, n-1] = data[i+1, j-1, k]
             elseif full && n == N 
-                buf[m+1, n+1] = data[i, j+1, k]
+                buf[m+1, n+1] = data[i+1, j+1, k]
             end
         end
 

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -5,14 +5,18 @@ struct Stencil{N, Dim, U}
     Stencil{N}(dims, arrays) where N = new{N, typeof(dims), typeof(arrays)}(dims, arrays) 
 end
 
+abstract type StencilKind end
+struct SevenPoint <: StencilKind end
+struct Full <: StencilKind end
+
 @init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
     include("custencil.jl")
 end
 
 # note this 3D only
-function stencil(dims, args::Vararg{<:Any, N}) where N
+function stencil(dims, kind, args::Vararg{<:Any, N}) where N
     if isdevice()
-        return CuStencil.stencil(dims, args...)
+        return CuStencil.stencil(dims, kind, args...)
     else
         return Stencil{N}(dims, args)
     end

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -1,0 +1,129 @@
+using StaticArrays
+using CUDAnative
+using GPUifyLoops
+using OffsetArrays
+using CuArrays
+using Adapt
+
+# TODO: Add an option to load in the full 3x3x3x stencil including
+# the 1,1 and I+1,I+1 corners
+Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(Adapt.adapt(to, parent(x)), x.offsets)
+
+struct Stencil{N, Dim, Shmem, U}
+    dims::Dim
+    buf::Shmem
+    arrays::U
+    Stencil{N}(dims, shmem, arrays) where N = new{N, typeof(dims), typeof(shmem), typeof(arrays)}(dims, shmem, arrays) 
+end
+
+# note this 3D only
+function stencil(dims, args::Vararg{<:Any, N}) where N
+    eltypes = map(eltype, args)
+    T = reduce(promote_type, eltypes)
+    @assert Base.isconcretetype(T)
+
+    buf = @cuDynamicSharedMem T (blockDim().x+2, blockDim().y+2)
+    Stencil{N}(dims, buf, args)
+end
+
+function load_stencil!(buf, data, i, j, k)
+    # translate between local to global indices
+    m = threadIdx().x
+    n = threadIdx().y
+    # halo region 
+    m, n = m+1, n+1
+
+    buf[m, n] =  data[i, j, k]
+
+    if m == 2 
+        buf[m-1, n] = data[i-1, j, k]
+    else m == blockDim().x+1 # boundary of block
+        buf[m+1, n] = data[i+1, j, k]
+    end
+    if n == 2
+        buf[m, n-1, k] = data[i, j-1, k]
+    else n == blockDim().y+1 # boundary of block
+        buf[m, n+1, k] = data[i, j+1, k]
+    end
+    # NOTE we don't load in the corners yet
+    sync_warp()
+    return m, n
+end
+
+function load_slice(buf,m,n)
+    # SMatrix{3,3}(view(buf, m-1:m+1, n-1:n+1))
+    inds = CartesianIndices((m-1:m+1, n-1:n+1))
+    data = ntuple(Val(9)) do i
+        buf[inds[i]]
+    end
+    SMatrix{3,3}(data)
+end
+
+function Base.iterate(stencil::Stencil{N}) where N
+    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    k = 1
+    I, J, K = stencil.dims
+    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+        return nothing
+    end
+
+    buf = stencil.buf
+
+    regions = ntuple(Val(N)) do ind
+        data = stencil.arrays[ind]
+        # load the boundary
+        m, n = load_stencil!(buf, data, i, j, k-1)
+        pre = load_slice(buf, m, n)
+
+        # m, n = load_stencil!(buf, data, i, j, k)
+        # current = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
+
+        # m, n = load_stencil!(buf, data, i, j, k+1)
+        # next = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
+
+        # ldata = cat(pre, current, next, dims=3)
+    end
+
+    ((i,j,k,regions...), (regions, k+1))
+end
+
+
+function Base.iterate(stencil::Stencil{N}, (regions, k)) where N
+    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+
+    I, J, K = stencil.dims
+    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+        return nothing
+    end
+
+    buf = stencil.buf
+
+    next_regions = ntuple(Val(N)) do ind
+        data = stencil.arrays[ind]
+        old = regions[ind]
+
+        m, n = load_stencil!(buf, data, i, j, k+1)
+        next = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
+        ldata = cat(old[:,:,2], old[:,:,3], next, dims=3)
+    end
+
+    ((i,j,k, next_regions...), (next_regions, k+1))
+end
+
+# function kernel(out, U)
+#     for (i,j,k, u) in stencil((32,32,32), U) 
+#         out[i, j, k] = (u[3, 2, 2] - u[2, 2, 2]) + 0.5 * (u[2, 1, 2] + u[2, 3, 2])
+#     end
+#     return nothing
+# end
+# 
+# function test(out, U)
+#     shmem = 8*8*sizeof(eltype(out))
+#     k = GPUifyLoops.contextualize(kernel)
+#     @cuda threads=(8,8) blocks=(4,4) k(out, U)
+# end
+# 
+# out = OffsetArray(CuArray(zeros(34,34,34)), 0:33, 0:33, 0:33);
+# A = OffsetArray(CuArray(rand(34,34,34)), 0:33, 0:33, 0:33);

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -1,129 +1,53 @@
-using StaticArrays
-using CUDAnative
-using GPUifyLoops
-using OffsetArrays
-using CuArrays
-using Adapt
 
-# TODO: Add an option to load in the full 3x3x3x stencil including
-# the 1,1 and I+1,I+1 corners
-Adapt.adapt_structure(to, x::OffsetArray) = OffsetArray(Adapt.adapt(to, parent(x)), x.offsets)
-
-struct Stencil{N, Dim, Shmem, U}
+struct Stencil{N, Dim, U}
     dims::Dim
-    buf::Shmem
     arrays::U
-    Stencil{N}(dims, shmem, arrays) where N = new{N, typeof(dims), typeof(shmem), typeof(arrays)}(dims, shmem, arrays) 
+    Stencil{N}(dims, arrays) where N = new{N, typeof(dims), typeof(arrays)}(dims, arrays) 
+end
+
+@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+    include("custencil.jl")
 end
 
 # note this 3D only
 function stencil(dims, args::Vararg{<:Any, N}) where N
-    eltypes = map(eltype, args)
-    T = reduce(promote_type, eltypes)
-    @assert Base.isconcretetype(T)
-
-    buf = @cuDynamicSharedMem T (blockDim().x+2, blockDim().y+2)
-    Stencil{N}(dims, buf, args)
-end
-
-function load_stencil!(buf, data, i, j, k)
-    # translate between local to global indices
-    m = threadIdx().x
-    n = threadIdx().y
-    # halo region 
-    m, n = m+1, n+1
-
-    buf[m, n] =  data[i, j, k]
-
-    if m == 2 
-        buf[m-1, n] = data[i-1, j, k]
-    else m == blockDim().x+1 # boundary of block
-        buf[m+1, n] = data[i+1, j, k]
+    if isdevice()
+        return CuStencil.stencil(dims, args...)
+    else
+        return Stencil{N}(dims, args)
     end
-    if n == 2
-        buf[m, n-1, k] = data[i, j-1, k]
-    else n == blockDim().y+1 # boundary of block
-        buf[m, n+1, k] = data[i, j+1, k]
-    end
-    # NOTE we don't load in the corners yet
-    sync_warp()
-    return m, n
-end
-
-function load_slice(buf,m,n)
-    # SMatrix{3,3}(view(buf, m-1:m+1, n-1:n+1))
-    inds = CartesianIndices((m-1:m+1, n-1:n+1))
-    data = ntuple(Val(9)) do i
-        buf[inds[i]]
-    end
-    SMatrix{3,3}(data)
 end
 
 function Base.iterate(stencil::Stencil{N}) where N
-    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    k = 1
+    i, j, k = (1, 1, 1)
     I, J, K = stencil.dims
-    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+    inds = CartesianIndices((1:I, 1:J, 1:K))
+    if !checkbounds(Bool, inds, i, j, k)
         return nothing
     end
-
-    buf = stencil.buf
 
     regions = ntuple(Val(N)) do ind
         data = stencil.arrays[ind]
-        # load the boundary
-        m, n = load_stencil!(buf, data, i, j, k-1)
-        pre = load_slice(buf, m, n)
-
-        # m, n = load_stencil!(buf, data, i, j, k)
-        # current = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
-
-        # m, n = load_stencil!(buf, data, i, j, k+1)
-        # next = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
-
-        # ldata = cat(pre, current, next, dims=3)
+        SArray{Tuple{3,3,3}}(view(data, i-1:i+1, j-1:j+1, k-1:k+1))
     end
 
-    ((i,j,k,regions...), (regions, k+1))
+    I = nextind(inds, CartesianIndex(i,j,k))
+    ((i,j,k,regions...), I)
 end
 
-
-function Base.iterate(stencil::Stencil{N}, (regions, k)) where N
-    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-
+function Base.iterate(stencil::Stencil{N}, I) where N
+    i, j, k = I.I
     I, J, K = stencil.dims
-    if !checkbounds(Bool, CartesianIndices((1:I, 1:J, 1:K)), i,j,k)
+    inds = CartesianIndices((1:I, 1:J, 1:K))
+    if !checkbounds(Bool, inds, i, j, k)
         return nothing
     end
 
-    buf = stencil.buf
-
-    next_regions = ntuple(Val(N)) do ind
+    regions = ntuple(Val(N)) do ind
         data = stencil.arrays[ind]
-        old = regions[ind]
-
-        m, n = load_stencil!(buf, data, i, j, k+1)
-        next = SMatrix{3,3}(view(buf, m-1:m+1, n-1:m+1))
-        ldata = cat(old[:,:,2], old[:,:,3], next, dims=3)
+        SArray{Tuple{3,3,3}}(view(data, i-1:i+1, j-1:j+1, k-1:k+1))
     end
 
-    ((i,j,k, next_regions...), (next_regions, k+1))
+    I = nextind(inds, I)
+    ((i,j,k,regions...), I)
 end
-
-# function kernel(out, U)
-#     for (i,j,k, u) in stencil((32,32,32), U) 
-#         out[i, j, k] = (u[3, 2, 2] - u[2, 2, 2]) + 0.5 * (u[2, 1, 2] + u[2, 3, 2])
-#     end
-#     return nothing
-# end
-# 
-# function test(out, U)
-#     shmem = 8*8*sizeof(eltype(out))
-#     k = GPUifyLoops.contextualize(kernel)
-#     @cuda threads=(8,8) blocks=(4,4) k(out, U)
-# end
-# 
-# out = OffsetArray(CuArray(zeros(34,34,34)), 0:33, 0:33, 0:33);
-# A = OffsetArray(CuArray(rand(34,34,34)), 0:33, 0:33, 0:33);

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -39,8 +39,8 @@ function Base.iterate(stencil::Stencil{N}) where N
     ((i,j,k,regions...), I)
 end
 
-function Base.iterate(stencil::Stencil{N}, I) where N
-    i, j, k = I.I
+function Base.iterate(stencil::Stencil{N}, Idx) where N
+    i, j, k = Idx.I
     I, J, K = stencil.dims
     inds = CartesianIndices((1:I, 1:J, 1:K))
     if !checkbounds(Bool, inds, i, j, k)
@@ -52,6 +52,6 @@ function Base.iterate(stencil::Stencil{N}, I) where N
         SArray{Tuple{3,3,3}}(view(data, i-1:i+1, j-1:j+1, k-1:k+1))
     end
 
-    I = nextind(inds, I)
-    ((i,j,k,regions...), I)
+    Idx = nextind(inds, Idx)
+    ((i,j,k,regions...), Idx)
 end


### PR DESCRIPTION
Tried to use the `stencil` abstraction from PR #81 to get a Laplacian example going, which should benefit from shared memory. Will later extend to a more expensive/demanding kernel to see how `stencil` scales, although will need to switch from `@benchmark` to `nvprof`.

This branch is a little dirty so probably should not merge. But figured it's not a bad place to put the example until it works.

The vanilla kernel works in the example, but the kernel with `stencil` does not. Here's the error I'm getting when I run the example script

```
ERROR: LoadError: InvalidIRError: compiling laplacian_stencil!(Cassette.Context{nametype(Ctx),Nothing,Nothing,getfield(GPUifyLoops, Symbol("##PassType#363")),Nothing,Cassette.DisableHooks}, typeof(laplacian_stencil!), OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}}, OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}}, OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}}, OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}}) resulted in invalid LLVM IR
Reason: unsupported call to the Julia runtime (call to jl_f_getfield)
Stacktrace:
 [1] indexed_iterate at tuple.jl:63
 [2] laplacian_stencil! at /home/ali-ramadhan/GPUifyLoops.jl/examples/laplacian_stencil.jl:50
 [3] overdub at /home/ali-ramadhan/.julia/packages/Cassette/YCOeN/src/overdub.jl:0
Stacktrace:
 [1] check_ir(::CUDAnative.CompilerJob, ::LLVM.Module) at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/validation.jl:114
 [2] macro expansion at /home/ali-ramadhan/.julia/packages/TimerOutputs/7zSea/src/TimerOutput.jl:216 [inlined]
 [3] #codegen#136(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Function, ::Symbol, ::CUDAnative.CompilerJob) at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/driver.jl:186
 [4] #codegen at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/driver.jl:0 [inlined]
 [5] #compile#135(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Function, ::Symbol, ::CUDAnative.CompilerJob) at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/driver.jl:47
 [6] #compile at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/common.jl:0 [inlined]
 [7] #compile#134 at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/compiler/driver.jl:28 [inlined]
 [8] #compile at ./none:0 [inlined] (repeats 2 times)
 [9] macro expansion at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/execution.jl:389 [inlined]
 [10] #cufunction#176(::String, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(cufunction), ::typeof(Cassette.overdub), ::Type{Tuple{Cassette.Context{nametype(Ctx),Nothing,Nothing,getfield(GPUifyLoops, Symbol("##PassType#363")),Nothing,Cassette.DisableHooks},typeof(laplacian_stencil!),OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}},OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}},OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}},OffsetArray{Float64,3,CuDeviceArray{Float64,3,CUDAnative.AS.Global}}}}) at /home/ali-ramadhan/.julia/packages/CUDAnative/Lr0yj/src/execution.jl:357
 [11] (::getfield(CUDAnative, Symbol("#kw##cufunction")))(::NamedTuple{(:name,),Tuple{String}}, ::typeof(cufunction), ::Function, ::Type) at ./none:0
 [12] macro expansion at /home/ali-ramadhan/GPUifyLoops.jl/src/GPUifyLoops.jl:126 [inlined]
 [13] macro expansion at ./gcutils.jl:87 [inlined]
 [14] #launch#62(::Base.Iterators.Pairs{Symbol,Tuple{Int64,Int64,Int64},Tuple{Symbol,Symbol},NamedTuple{(:threads, :blocks),Tuple{Tuple{Int64,Int64,Int64},Tuple{Int64,Int64,Int64}}}}, ::Function, ::CUDA, ::typeof(laplacian_stencil!), ::OffsetArray{Float64,3,CuArray{Float64,3}}, ::Vararg{OffsetArray{Float64,3,CuArray{Float64,3}},N} where N) at /home/ali-ramadhan/GPUifyLoops.jl/src/GPUifyLoops.jl:122
 [15] (::getfield(GPUifyLoops, Symbol("#kw##launch")))(::NamedTuple{(:threads, :blocks),Tuple{Tuple{Int64,Int64,Int64},Tuple{Int64,Int64,Int64}}}, ::typeof(GPUifyLoops.launch), ::CUDA, ::typeof(laplacian_stencil!), ::OffsetArray{Float64,3,CuArray{Float64,3}}, ::Vararg{OffsetArray{Float64,3,CuArray{Float64,3}},N} where N) at ./none:0
 [16] macro expansion at /home/ali-ramadhan/.julia/packages/CuArrays/wXQp8/src/utils.jl:81 [inlined]
 [17] ##core#397() at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:297
 [18] ##sample#398(::BenchmarkTools.Parameters) at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:303
 [19] #_run#4(::Bool, ::String, ::Base.Iterators.Pairs{Symbol,Integer,NTuple{4,Symbol},NamedTuple{(:samples, :evals, :gctrial, :gcsample),Tuple{Int64,Int64,Bool,Bool}}}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#396")}, ::BenchmarkTools.Parameters) at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:331
 [20] (::getfield(Base, Symbol("#inner#2")){Base.Iterators.Pairs{Symbol,Integer,NTuple{5,Symbol},NamedTuple{(:verbose, :samples, :evals, :gctrial, :gcsample),Tuple{Bool,Int64,Int64,Bool,Bool}}},typeof(BenchmarkTools._run),Tuple{BenchmarkTools.Benchmark{Symbol("##benchmark#396")},BenchmarkTools.Parameters}})() at ./none:0
 [21] #invokelatest#1 at ./essentials.jl:746 [inlined]
 [22] #invokelatest at ./none:0 [inlined]
 [23] #run_result#37 at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:32 [inlined]
 [24] #run_result at ./none:0 [inlined]
 [25] #run#39(::Base.Iterators.Pairs{Symbol,Integer,NTuple{5,Symbol},NamedTuple{(:verbose, :samples, :evals, :gctrial, :gcsample),Tuple{Bool,Int64,Int64,Bool,Bool}}}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#396")}, ::BenchmarkTools.Parameters) at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:46
 [26] #run at ./none:0 [inlined] (repeats 2 times)
 [27] #warmup#42 at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:79 [inlined]
 [28] warmup(::BenchmarkTools.Benchmark{Symbol("##benchmark#396")}) at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:79
 [29] top-level scope at /home/ali-ramadhan/.julia/packages/BenchmarkTools/7aqwe/src/execution.jl:213
 [30] include at ./boot.jl:326 [inlined]
 [31] include_relative(::Module, ::String) at ./loading.jl:1038
 [32] include(::Module, ::String) at ./sysimg.jl:29
 [33] exec_options(::Base.JLOptions) at ./client.jl:267
 [34] _start() at ./client.jl:436
in expression starting at /home/ali-ramadhan/GPUifyLoops.jl/examples/laplacian_stencil.jl:55
```

cc @vchuravy 

---

This PR is dedicated to our dearly departed @edoddridge