### PR TITLE
Add read only load function

### DIFF
--- a/src/GPUifyLoops.jl
+++ b/src/GPUifyLoops.jl
@@ -25,6 +25,7 @@ export @scratch, @shmem
 export contextualize
 export @unroll
 export @launch
+export read_only_load
 
 ##
 # contextualize
@@ -234,6 +235,11 @@ end
 ###
 include("scratch.jl")
 include("shmem.jl")
+
+###
+# Read only loads
+###
+include("read_only_load.jl")
 
 ###
 # Loopinfo

--- a/src/read_only_load.jl
+++ b/src/read_only_load.jl
@@ -1,0 +1,20 @@
+@init @require CUDAnative="be33ccc6-a3ff-5ff2-a52e-74243cff1e17" begin
+    using .CUDAnative
+
+    @Base.propagate_inbounds function __read_only_load(::CUDA, A::CUDAnative.CuDeviceArray, index::Integer)
+        CUDAnative.ldg(A, index)
+    end
+end
+
+@Base.propagate_inbounds __read_only_load(::CPU, A::Array, index::Integer) = A[index]
+
+"""
+    read_only_load(A, i)
+
+Index the array `A` with the linear index `i`.  On the GPU this uses the
+read-only texture cache (e.g., via `ldg` in CUDAnative) so the memory `A`
+refers to must not be written to during the kernel execution.
+
+See also: `Base.getindex`, `CUDAnative.ldg`
+"""
+@Base.propagate_inbounds read_only_load(A, index) = __read_only_load(backend(), A, index)

--- a/test/test.jl
+++ b/test/test.jl
@@ -114,6 +114,30 @@ end
             @test f5.(data) ≈ cufdata
         end
     end
+
+    @testset "read only load" begin
+        global read_only_kernel, con_read_only_kernel
+        read_only_kernel(A, B) = (B[1] = read_only_load(A, 1); return nothing)
+        con_read_only_kernel(A, B) = GPUifyLoops.contextualize(read_only_kernel)(A, B)
+        tt = Tuple{CUDAnative.CuDeviceArray{Float32, 1, CUDAnative.AS.Global},
+                   CUDAnative.CuDeviceArray{Float32, 1, CUDAnative.AS.Global}}
+
+        asm = sprint(io->CUDAnative.code_llvm(io, con_read_only_kernel, tt, kernel=true,
+                                              optimize=false, dump_module=true))
+
+        @test occursin("llvm.nvvm.ldg.global.f.f32", asm)
+
+        A = rand(Float32, 1024)
+        B = similar(A)
+        @launch CPU() threads=length(A) read_only_kernel(A, B)
+        @test A[1] == B[1]
+
+        cuA = CuArray(A)
+        cuB = similar(cuA)
+
+        @launch CUDA() threads=length(cuA) read_only_kernel(cuA, cuB)
+        @test A[1] == Array(cuB)[1]
+    end
 end
 
 function kernel3!(A)


### PR DESCRIPTION
This adds a wrapper for `CUDAnative.ldg` so that we can specify GPU
loads using the read-only texture cache.  Currently the CPU version just
does a regular load.